### PR TITLE
Include TextPaint::Timing events from Viasat Browser

### DIFF
--- a/internal/snappi/image_plotter.py
+++ b/internal/snappi/image_plotter.py
@@ -1,6 +1,11 @@
 from matplotlib import pyplot as plt
 from matplotlib.patches import Rectangle
 
+COLORS = {
+    'image': ['r', 'g'],
+    'text': ['b', 'm'],
+}
+
 def plot_rects(rects, output_filepath):
     fig, ax = plt.subplots()
     ax.set_xlim(0, 1200)
@@ -11,14 +16,16 @@ def plot_rects(rects, output_filepath):
         x, y, width, height = rect_data["x"], rect_data["y"], rect_data["width"], rect_data["height"]
         events = rect_data["events"]
 
+        colors = COLORS[events[0]['type']]
+
         rect = {"x": x, "y": y, "width": width, "height": height}
         area = rect_data["area"]
 
-        color = 'r'
+        color = colors[0]
         has_multiple_paint_events = False
 
         if len(events) > 1:
-            color = 'g'
+            color = colors[1]
             has_multiple_paint_events = True
 
         ax.add_patch(Rectangle((rect["x"], rect["y"]), rect["width"], rect["height"], linewidth=1, edgecolor=color, facecolor='none'))

--- a/internal/snappi/snappi_page_events_generator.py
+++ b/internal/snappi/snappi_page_events_generator.py
@@ -98,8 +98,9 @@ def generate_page_events(trace_data, rects, navigation_start_event, event_names)
             largest_area = area
             snappi_lcp = events[0]
 
-        if not all_images_painted or events[0]["timestamp"] > all_images_painted["timestamp"]:
-            all_images_painted = events[0]
+        if events[0]["type"] == "image":
+            if not all_images_painted or events[0]["timestamp"] > all_images_painted["timestamp"]:
+                all_images_painted = events[0]
 
     for event_name, event_info in found_events.items():
         if event_name == "navigationStart":
@@ -143,7 +144,7 @@ def generate_page_events(trace_data, rects, navigation_start_event, event_names)
             }
         })
 
-    result["page_events"] = sorted(result["page_events"], 
+    result["page_events"] = sorted(result["page_events"],
                                    key=lambda x: x.get("timestamp", 0) if not x.get("message") else float('inf'))
 
     return result

--- a/internal/snappi/snappi_trace_parser.py
+++ b/internal/snappi/snappi_trace_parser.py
@@ -17,7 +17,7 @@ event_names = [
 
 def filter_trace_events(trace_data, event_names):
     filtered_trace_data = {"traceEvents": []}
-    event_names += ["navigationStart", "ImagePaint::Timing"]
+    event_names += ["navigationStart", "ImagePaint::Timing", "TextPaint::Timing"]
 
     for event in trace_data["traceEvents"]:
         if event.get("name") in event_names:
@@ -40,7 +40,7 @@ def snappi_parse_trace(trace_file_dict):
         "snappi_rects": rects,
         "snappi_pageEvents": result["page_events"]
     }
-    
+
     return output
 
 if __name__ == "__main__":


### PR DESCRIPTION
VB now generates TextPaint::Timing events for paint events of text. This patch adds support to parse those events and plot them with matplotlib.

Example of Boston globe:

![Screenshot 2024-02-21 at 12 17 12 PM](https://github.com/shubhsherl/wptagent/assets/5600524/b447d065-a40f-45bc-8d53-53d0dfae6697)

Skull candy:

![Screenshot 2024-02-21 at 1 36 29 PM](https://github.com/shubhsherl/wptagent/assets/5600524/c2f9c326-9021-4c3d-bc0d-93c36f25a471)
